### PR TITLE
helper method to determine empty search

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,8 +1,9 @@
 class TermsController < ApplicationController
+  include TermsHelper
   before_action :authenticate_user!, :except => [:index, :show]
 
   def index
-    if params
+    if search_contains_characters(params)
       query = params[:term_en]
       @terms = Term.where(term_en: query)
     else

--- a/app/helpers/terms_helper.rb
+++ b/app/helpers/terms_helper.rb
@@ -2,5 +2,10 @@ module TermsHelper
   def term_params
     params.require(:term).permit(:term_en, :term_ar, :ac_field_en, :ac_field_ar, :definition_en, :definition_ar, :context_en, :context_ar)
   end
-  
+
+  def search_contains_characters(params)
+    match_data = params[:term_en] =~ /\w/
+    match_data != nil
+  end
+
 end


### PR DESCRIPTION
closes #39 
Checks whether the search params contains a word; if not then returns full list of terms
