### PR TITLE
removes ['term'] from method

### DIFF
--- a/app/helpers/terms_helper.rb
+++ b/app/helpers/terms_helper.rb
@@ -1,7 +1,7 @@
 module TermsHelper
 
   def term_params
-    params['term'].permit(:term_en, :term_ar, :ac_field_en, :ac_field_ar, :definition_en, :definition_ar, :context_en, :context_ar)
+    params.permit(:term_en, :term_ar, :ac_field_en, :ac_field_ar, :definition_en, :definition_ar, :context_en, :context_ar)
   end
 
   def search_contains_characters(params)


### PR DESCRIPTION
Fixes typo in terms_helper
